### PR TITLE
Make callback optional and dynamically configurable

### DIFF
--- a/lib/lastfm_strategy.js
+++ b/lib/lastfm_strategy.js
@@ -23,8 +23,8 @@ function LastfmStrategy(options, verify){
   this.name = 'lastfm';
   this.api_key = options.api_key || options.clientID;
   this.secret = options.secret || options.clientSecret;
-  this.callbackURL = options.callback_url || options.callbackURL;
-
+  var cb = options.callback_url || options.callbackURL;
+  this.callbackURL = cb && cb.call ? cb : () => cb;
 
   this._verify = verify;
   this._lastfm = new LastFmNode({
@@ -36,8 +36,7 @@ function LastfmStrategy(options, verify){
 
 LastfmStrategy.prototype.authenticate = function(request, options){
   var self = this;
-  var authUrl = self.getAuthenticationUrl({cb:self.callbackURL});
-
+  var authUrl = self.getAuthenticationUrl({cb: self.callbackURL(request)});
 
   if (request.query && request.query.token){
     var token = request.query.token;

--- a/lib/lastfm_strategy.js
+++ b/lib/lastfm_strategy.js
@@ -15,7 +15,6 @@ function LastfmStrategy(options, verify){
   options = options || {};
   if (!options.api_key && !options.clientID)  { throw new TypeError('LastfmStrategy requires a clientID obtained from http://www.last.fm/api/account/create'); }
   if (!options.secret && !options.clientSecret)  { throw new TypeError('LastfmStrategy requires a clientSecret obtained from http://www.last.fm/api/account/create'); }
-  if (!options.callback_url && !options.callbackURL)  { throw new TypeError('LastfmStrategy requires a callbackURL option'); }
 
   if (!verify || typeof(verify) != 'function')  { throw new TypeError('LastfmStrategy requires verify callback function'); }
 
@@ -70,18 +69,21 @@ LastfmStrategy.prototype.authenticate = function(request, options){
 
 
 LastfmStrategy.prototype.getAuthenticationUrl = function(param) {
-  var params = param ;
-  if (!param) params = {};
+  var params = param || {};
   var baseUrl = 'http://www.last.fm/api/auth';
   var urlParts = url.parse(baseUrl);
 
-  urlParts.query = {};;
-  urlParts.query.api_key = this.api_key;
+  urlParts.query = {
+    api_key: this.api_key
+  };
+  if (params.token) {
+    urlParts.query.token = params.token;
+  }
+  if (params.cb) {
+    urlParts.query.cb = params.cb;
+  }
 
-  if (params.token) { urlParts.query.token = params.token; }
-
-  var rtn = `${url.format(urlParts)}&cb=${this.callbackURL}`;
-  return rtn ;
+  return url.format(urlParts);
 };
 
 

--- a/test/lastfm_strategy.test.js
+++ b/test/lastfm_strategy.test.js
@@ -47,9 +47,36 @@ describe('Strategy', function() {
     });
 
     it('should be redirected to lastfm for auth', function() {
-      expect(url).to.equal('http://www.last.fm/api/auth?api_key=ABC123&cb=http://localhost:8000');
+      expect(url).to.equal('http://www.last.fm/api/auth?api_key=ABC123&cb=http%3A%2F%2Flocalhost%3A8000');
     });
   });
+
+  describe('authorization request with no callback', function() {
+    var strategy = new LastFmStrategy({
+      api_key: 'ABC123',
+      secret: 'secret'
+    }, function() {});
+
+
+    var url;
+
+    before(function(done) {
+      chai.passport.use(strategy)
+        .redirect(function(u) {
+          url = u;
+          done();
+        })
+        .req(function(req) {
+        })
+        .authenticate({ display: 'mobile' });
+    });
+
+    it('should be redirected to lastfm for auth', function() {
+      expect(url).to.equal('http://www.last.fm/api/auth?api_key=ABC123');
+    });
+  });
+
+
 
 
 

--- a/test/lastfm_strategy.test.js
+++ b/test/lastfm_strategy.test.js
@@ -76,6 +76,32 @@ describe('Strategy', function() {
     });
   });
 
+  describe('authorization request with dynamic callback', function() {
+    var strategy = new LastFmStrategy({
+      callbackURL: req => req.cbProperty,
+      api_key: 'ABC123',
+      secret: 'secret'
+    }, function() {});
+
+
+    var url;
+
+    before(function(done) {
+      chai.passport.use(strategy)
+        .redirect(function(u) {
+          url = u;
+          done();
+        })
+        .req(function(req) {
+          req.cbProperty = 'fake-cb-url'
+        })
+        .authenticate({ display: 'mobile' });
+    });
+
+    it('should be redirected to lastfm for auth with the dynamic cb url', function() {
+      expect(url).to.equal('http://www.last.fm/api/auth?api_key=ABC123&cb=fake-cb-url');
+    });
+  });
 
 
 


### PR DESCRIPTION
Hi, I had a couple issues with callback handling in this strategy.

Firstly I don't think the callback should be required as lastfm will use the configured callbackurl in the oauth app if this is not supplied.

If you do supply a callback then it seems lasfm requires it to be an absolute url which is unusual and annoying as they already have the base url as part of the oauth app config. As a workaround I've made it possible to generate the callback url based on the request so we can do something like 

```
const callbackUrl = '/callback/lastfm/';
return new LastFMStrategy({
            callbackURL: req => url.format(
                Object.assign(url.parse(req.headers.referer), {pathname: callbackUrl})
            ),
...
```

Let me know what you think.

Thanks.
