### PR TITLE
Changing baseUrl to https

### DIFF
--- a/lib/lastfm_strategy.js
+++ b/lib/lastfm_strategy.js
@@ -72,7 +72,7 @@ LastfmStrategy.prototype.authenticate = function(request, options){
 LastfmStrategy.prototype.getAuthenticationUrl = function(param) {
   var params = param ;
   if (!param) params = {};
-  var baseUrl = 'http://www.last.fm/api/auth';
+  var baseUrl = 'https://www.last.fm/api/auth';
   var urlParts = url.parse(baseUrl);
 
   urlParts.query = {};;


### PR DESCRIPTION
Android 9 isn't allowing http by default anymore, simply changing the baseUrl to use https solves the _err_cleartext_not_permitted_ issue on Android.