### PR TITLE
Enable dynamic callback url

### DIFF
--- a/lib/lastfm_strategy.js
+++ b/lib/lastfm_strategy.js
@@ -15,7 +15,6 @@ function LastfmStrategy(options, verify){
   options = options || {};
   if (!options.api_key && !options.clientID)  { throw new TypeError('LastfmStrategy requires a clientID obtained from http://www.last.fm/api/account/create'); }
   if (!options.secret && !options.clientSecret)  { throw new TypeError('LastfmStrategy requires a clientSecret obtained from http://www.last.fm/api/account/create'); }
-  if (!options.callback_url && !options.callbackURL)  { throw new TypeError('LastfmStrategy requires a callbackURL option'); }
 
   if (!verify || typeof(verify) != 'function')  { throw new TypeError('LastfmStrategy requires verify callback function'); }
 
@@ -37,8 +36,6 @@ function LastfmStrategy(options, verify){
 
 LastfmStrategy.prototype.authenticate = function(request, options){
   var self = this;
-  var authUrl = self.getAuthenticationUrl({cb:self.callbackURL});
-
 
   if (request.query && request.query.token){
     var token = request.query.token;
@@ -62,6 +59,11 @@ LastfmStrategy.prototype.authenticate = function(request, options){
     this._lastfm.request('auth.getSession', lastfm_opts);
   }
   else{
+    var callbackURL = options.callback_url || options.callbackURL || self.callbackURL;
+
+    if (!callbackURL) throw new TypeError('LastfmStrategy requires a callbackURL option');
+
+    var authUrl = self.getAuthenticationUrl({cb:callbackURL});
     self.redirect(authUrl);
   }
 }
@@ -80,7 +82,7 @@ LastfmStrategy.prototype.getAuthenticationUrl = function(param) {
 
   if (params.token) { urlParts.query.token = params.token; }
 
-  var rtn = `${url.format(urlParts)}&cb=${this.callbackURL}`;
+  var rtn = `${url.format(urlParts)}&cb=${param.cb}`;
   return rtn ;
 };
 


### PR DESCRIPTION
This PR adds the ability to pass a dynamic callback url as option while calling `passport.authenticate` e.g. to set a dynamic hostname or add a custom parameter.

For example:
```
passport.authenticate('lastfm', {
  callbackURL: `https://${req.headers.host}/auth/lastfm/callback`,
})
```